### PR TITLE
Fixes context menu click events for pages tree in b/pages#index.

### DIFF
--- a/app/assets/javascripts/backend/tree.js
+++ b/app/assets/javascripts/backend/tree.js
@@ -63,7 +63,7 @@ var tree = tree || {
 
   contextmenu_remove_listener: function(obj) {
     var instance = tree.vars.container.jstree(true);
-    var node = instance.get_node(obj.reference.prevObject.selector);
+    var node = instance.get_node(obj.reference);
 
     $.ajax({
       data: { id: node.data.id },
@@ -80,7 +80,7 @@ var tree = tree || {
 
   contextmenu_toggle_visibility_listener: function(obj) {
     var instance = tree.vars.container.jstree(true);
-    var node = instance.get_node(obj.reference.prevObject.selector);
+    var node = instance.get_node(obj.reference);
 
     $.ajax({
       data: { id: node.data.id },

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+5.9.0 - xxxx-xx-xx
+--
+* Fixes issue in pages module that prevented you from clicking the context
+  menu items.
+
+
 5.8.0 - 2017-04-12
 --
 * Add missing ```author``` key to form translations.


### PR DESCRIPTION
Probably caused by an ECMAScript update by updating the browser. The function that broke can apparently accept a plain jQuery object, so it should be fine in the future.