### PR TITLE
Adds tel and email as valid FormField types.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    udongo (6.2.0)
+    udongo (6.2.1)
       acts_as_list (~> 0.7, >= 0.7.2)
       bcrypt (~> 3.1, >= 3.1.7)
       carrierwave (~> 0.10, >= 0.10.0)
@@ -266,7 +266,7 @@ GEM
     rspec-support (3.5.0)
     ruby_dep (1.3.1)
     safe_yaml (1.0.4)
-    sass (3.4.23)
+    sass (3.4.24)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
       sass (~> 3.1)
@@ -274,9 +274,9 @@ GEM
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
     shellany (0.0.1)
-    simple_form (3.4.0)
-      actionpack (> 4, < 5.1)
-      activemodel (> 4, < 5.1)
+    simple_form (3.5.0)
+      actionpack (> 4, < 5.2)
+      activemodel (> 4, < 5.2)
     slop (3.6.0)
     sort_alphabetical (1.1.0)
       unicode_utils (>= 1.2.2)

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -5,7 +5,7 @@ class FormField < ApplicationRecord
   include Concerns::Translatable
   translatable_fields :label, :default_value
 
-  FIELD_TYPES = %w(string text integer collection)
+  FIELD_TYPES = %w(string text integer collection email tel)
 
   belongs_to :form
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+6.2.1 - 2017-06-02
+--
+* Added email and tel as valid form types for FormField.
+
+
 6.2.0 - 2017-06-02
 --
 * Removed the bootstrap source mapping reference in backend/bootstrap.scss.

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-6.2.1 - 2017-06-02
+6.2.1 - 2017-06-04
 --
 * Added email and tel as valid form types for FormField.
 

--- a/config/locales/nl_general.yml
+++ b/config/locales/nl_general.yml
@@ -3,8 +3,10 @@ nl:
     collections:
       form_field_type:
         collection: Collectie
+        email: E-mailadres
         integer: Getal
         string: Tekstregel
+        tel: Telefoonnummer
         text: Tekstvak
 
     type: Type

--- a/lib/udongo/version.rb
+++ b/lib/udongo/version.rb
@@ -1,3 +1,3 @@
 module Udongo
-  VERSION = '6.2.0'
+  VERSION = '6.2.1'
 end

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -42,7 +42,7 @@ describe FormField do
   end
 
   it 'FIELD_TYPES' do
-    expect(described_class::FIELD_TYPES).to eq %w(string text integer collection)
+    expect(described_class::FIELD_TYPES).to eq %w(string text integer collection email tel)
   end
 
   it '#respond_to?' do

--- a/upgrading.md
+++ b/upgrading.md
@@ -1,4 +1,8 @@
 # Upgrade guide
+## From 6.2.0 to 6.2.1
+### Formbuilder
+You can now use the ```tel``` and ```email``` type for form fields.
+
 ## From 6.1.0 to 6.2.0
 ### CollectionHelper
 You can now easily create collections to be used with SimpleForm by using


### PR DESCRIPTION
Both of these types are handled just like string types, but have some semantic meaning for SimpleForm along with inputs being rendered differently on mobile.