### PR TITLE
Reworks Udongo::Search::Frontend tests so we no longer have to rely on Page

### DIFF
--- a/lib/udongo/bogus_model.rb
+++ b/lib/udongo/bogus_model.rb
@@ -1,0 +1,34 @@
+# This class was made to help test class agnostic engine functionality that
+# requires model interfaces to work.
+#
+# An example would be tests for polymorphic associations:
+#   foo = Udongo::BogusModel.new(id: 37, description: 'foobar', hidden?: false)
+#   create(:search_index, searchable: foo, locale: 'nl')
+class Udongo::BogusModel < OpenStruct
+  attr_reader :id
+
+  def self.base_class
+    self.class
+  end
+
+  def self.primary_key
+    :id
+  end
+
+  def _read_attribute(attribute)
+    nil
+  end
+
+  def id
+    @id = rand(1..1000) unless @id
+    @id
+  end
+
+  def destroyed?
+    false
+  end
+
+  def new_record?
+    false
+  end
+end

--- a/lib/udongo/search/result_objects/base.rb
+++ b/lib/udongo/search/result_objects/base.rb
@@ -36,7 +36,7 @@ module Udongo
         end
 
         def hidden?
-          searchable.respond_to?(:visible) && searchable.hidden?
+          searchable.respond_to?(:visible?) && searchable.hidden?
         end
 
         def label

--- a/spec/lib/udongo/bogus_model_spec.rb
+++ b/spec/lib/udongo/bogus_model_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe Udongo::BogusModel do
+  let(:instance) { described_class.new }
+
+  describe '#id' do
+    it 'gives a random int > 0' do
+      expect(instance.id).to satisfy { |e| e > 0 }
+    end
+
+    it 'always returns the same value on multiple calls' do
+      id = instance.id
+      expect(instance.id).to eq id
+      expect(instance.id).to eq id
+      expect(instance.id).to eq id
+    end
+  end
+
+  it '#new_record?' do
+    expect(instance.new_record?).to be false
+  end
+
+  it '#destroyed?' do
+    expect(instance.destroyed?).to be false
+  end
+
+  it '#responds_to?' do
+    expect(instance).to respond_to(
+      :_read_attribute, :id, :destroyed?, :new_record?
+    )
+  end
+
+  it '.responds_to?' do
+    expect(described_class).to respond_to(:base_class, :primary_key)
+  end
+end

--- a/spec/lib/udongo/search/frontend_spec.rb
+++ b/spec/lib/udongo/search/frontend_spec.rb
@@ -16,23 +16,68 @@ describe Udongo::Search::Frontend do
       expect(instance.search).to eq []
     end
 
-    it 'filters on visibility' do
-      create(:page, description: 'foobar', visible: false)
-      page = create(:page, description: 'foobar', visible: true)
-      index = create(:search_index, searchable: page, locale: 'nl', name: 'description', value: 'foobar')
-      allow(instance).to receive(:indices) { [index] }
+    context 'filters on visibility' do
+      it 'shows visible' do
+        foo = Udongo::BogusModel.new(
+          description: 'foobar',
+          visible?: true,
+          hidden?: false,
+          published?: true,
+          unpublished?: false
+        )
 
-      expect(instance.search).to eq [{ label: 'foobar', value: nil }]
+        index = create(:search_index, searchable: foo, locale: 'nl', name: 'description', value: 'foobar')
+        allow(instance).to receive(:indices) { [index] }
+
+        expect(instance.search).to eq [{ label: 'foobar', value: nil }]
+      end
+
+      it 'skips hidden' do
+        foo = Udongo::BogusModel.new(
+          description: 'foobar',
+          visible?: false,
+          hidden?: true,
+          published?: true,
+          unpublished?: false
+        )
+
+        index = create(:search_index, searchable: foo, locale: 'nl', name: 'description', value: 'foobar')
+        allow(instance).to receive(:indices) { [index] }
+
+        expect(instance.search).to eq []
+      end
     end
 
-    it 'filters on publishable state' do
-      create(:page, description: 'foobar', visible: true)
-      page = create(:page, description: 'foobar', visible: true)
-      allow(page).to receive(:unpublished?) { true }
-      index = create(:search_index, searchable: page, locale: 'nl', name: 'description', value: 'foobar')
-      allow(instance).to receive(:indices) { [index] }
+    context 'filters on publishable state' do
+      it 'shows published' do
+        foo = Udongo::BogusModel.new(
+          description: 'foobar',
+          visible?: true,
+          hidden?: false,
+          published?: true,
+          unpublished?: false
+        )
 
-      expect(instance.search).to eq [{ label: 'foobar', value: nil }]
+        index = create(:search_index, searchable: foo, locale: 'nl', name: 'description', value: 'foobar')
+        allow(instance).to receive(:indices) { [index] }
+
+        expect(instance.search).to eq [{ label: 'foobar', value: nil }]
+      end
+
+      it 'skips unpublished' do
+        foo = Udongo::BogusModel.new(
+          description: 'foobar',
+          visible?: true,
+          hidden?: false,
+          published?: false,
+          unpublished?: true
+        )
+
+        index = create(:search_index, searchable: foo, locale: 'nl', name: 'description', value: 'foobar')
+        allow(instance).to receive(:indices) { [index] }
+
+        expect(instance.search).to eq []
+      end
     end
   end
 


### PR DESCRIPTION
Sometimes tests would fail because the system was looking for the (removed) ```Udongo::Search::ResultObjects::Frontend::Page``` class. In its subsequent calls it "sometimes" seemed to fall back on the ```::Page``` class, causing it to pass the existence check but fail the subsequent class call.

The related tests that triggered the above problem were brittle in the sense that they still relied on ```Page``` to be the subject for visible/publishable checks on the ```Udongo::Frontend::Search``` method. By removing the dependence on ```Page``` we fix the above problem.