### PR TITLE
Adds a third parameter to IconHelper#icon that makes it possible to pass additional HTML attributes, including additional classes.

### DIFF
--- a/app/helpers/icon_helper.rb
+++ b/app/helpers/icon_helper.rb
@@ -9,8 +9,12 @@ module IconHelper
   #
   #   ag 'icon\((:|")(\w+), '
   #
-  def icon(name, lbl = nil)
-    markup = content_tag :i, nil, class: "fa fa-#{name.to_s.tr('_', '-')}"
+  def icon(name, lbl = nil, options = {})
+    classes = "fa fa-#{name.to_s.tr('_', '-')}"
+    classes = classes.concat(" #{options[:class].to_s}") if options[:class]
+    options[:class] = classes
+
+    markup = content_tag :i, nil, options
     lbl ? "#{markup}&nbsp;#{lbl}".html_safe : markup
   end
 end

--- a/app/helpers/icon_helper.rb
+++ b/app/helpers/icon_helper.rb
@@ -1,6 +1,16 @@
 module IconHelper
-  def icon(name, label = nil)
+  # I wanted to make a named param out of label, though this would imply a
+  # backwards incompatible change that would require a non-trivial amount of
+  # editing.
+  #
+  # If you want to take this along with the next planned major release, you can
+  # use the following CMD in bash (assuming you have silver searcher installed)
+  # to get a list of all icon calls that pass anything more than just a name.
+  #
+  #   ag 'icon\((:|")(\w+), '
+  #
+  def icon(name, lbl = nil)
     markup = content_tag :i, nil, class: "fa fa-#{name.to_s.tr('_', '-')}"
-    label ? "#{markup}&nbsp;#{label}".html_safe : markup
+    lbl ? "#{markup}&nbsp;#{lbl}".html_safe : markup
   end
 end

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+7.1.3 - 2017-11-30
+--
+* Added a third parameter to IconHelper#icon that makes it possible to pass
+  additional HTML attributes, including additional classes.
+
+
 7.1.2 - 2017-11-19
 --
 * Make the plain/html content storage of the email model a lot bigger.

--- a/spec/helpers/icon_helper_spec.rb
+++ b/spec/helpers/icon_helper_spec.rb
@@ -35,5 +35,17 @@ describe IconHelper do
         expect(output).to be_a(ActiveSupport::SafeBuffer)
       end
     end
+
+    describe 'options param' do
+      it 'does not require a label' do
+        output = icon(:foo, nil, data: { testing: true })
+        expect(output).to eq '<i data-testing="true" class="fa fa-foo"></i>'
+      end
+
+      it 'adds classes without removing the pre-generated classes of "fa fa-name"' do
+        output = icon(:foo, nil, class: 'fa-border')
+        expect(output).to eq '<i class="fa fa-foo fa-border"></i>'
+      end
+    end
   end
 end

--- a/spec/helpers/icon_helper_spec.rb
+++ b/spec/helpers/icon_helper_spec.rb
@@ -5,25 +5,35 @@ describe IconHelper do
     it 'name as symbol' do
       output = icon(:foo)
       expect(output).to eq '<i class="fa fa-foo"></i>'
-      expect(output).to be_a(ActiveSupport::SafeBuffer)
     end
 
     it 'name as string' do
       output = icon('foo')
       expect(output).to eq '<i class="fa fa-foo"></i>'
-      expect(output).to be_a(ActiveSupport::SafeBuffer)
     end
 
     it 'name with underscores' do
       output = icon(:foo_bar_baz)
       expect(output).to eq '<i class="fa fa-foo-bar-baz"></i>'
-      expect(output).to be_a(ActiveSupport::SafeBuffer)
     end
 
-    it 'with a label' do
-      output = icon(:foo, 'Bar')
-      expect(output).to eq '<i class="fa fa-foo"></i>&nbsp;Bar'
-      expect(output).to be_a(ActiveSupport::SafeBuffer)
+    context 'when passing a label' do
+      it 'it returns the icon HTML with a label' do
+        output = icon(:foo, 'Bar')
+        expect(output).to eq '<i class="fa fa-foo"></i>&nbsp;Bar'
+      end
+
+      it 'returns an instance of ActiveSupport::SafeBuffer' do
+        output = icon(:foo, 'Bar')
+        expect(output).to be_a(ActiveSupport::SafeBuffer)
+      end
+    end
+
+    context 'when not passing a label' do
+      it 'returns an instance of ActiveSupport::SafeBuffer' do
+        output = icon(:foo, 'Bar')
+        expect(output).to be_a(ActiveSupport::SafeBuffer)
+      end
     end
   end
 end

--- a/spec/helpers/icon_helper_spec.rb
+++ b/spec/helpers/icon_helper_spec.rb
@@ -3,36 +3,30 @@ require 'rails_helper'
 describe IconHelper do
   describe '#icon' do
     it 'name as symbol' do
-      output = icon(:foo)
-      expect(output).to eq '<i class="fa fa-foo"></i>'
+      expect(icon(:foo)).to eq '<i class="fa fa-foo"></i>'
     end
 
     it 'name as string' do
-      output = icon('foo')
-      expect(output).to eq '<i class="fa fa-foo"></i>'
+      expect(icon('foo')).to eq '<i class="fa fa-foo"></i>'
     end
 
     it 'name with underscores' do
-      output = icon(:foo_bar_baz)
-      expect(output).to eq '<i class="fa fa-foo-bar-baz"></i>'
+      expect(icon(:foo_bar_baz)).to eq '<i class="fa fa-foo-bar-baz"></i>'
     end
 
     context 'when passing a label' do
       it 'it returns the icon HTML with a label' do
-        output = icon(:foo, 'Bar')
-        expect(output).to eq '<i class="fa fa-foo"></i>&nbsp;Bar'
+        expect(icon(:foo, 'Bar')).to eq '<i class="fa fa-foo"></i>&nbsp;Bar'
       end
 
       it 'returns an instance of ActiveSupport::SafeBuffer' do
-        output = icon(:foo, 'Bar')
-        expect(output).to be_a(ActiveSupport::SafeBuffer)
+        expect(icon(:foo, 'Bar')).to be_a(ActiveSupport::SafeBuffer)
       end
     end
 
     context 'when not passing a label' do
       it 'returns an instance of ActiveSupport::SafeBuffer' do
-        output = icon(:foo, 'Bar')
-        expect(output).to be_a(ActiveSupport::SafeBuffer)
+        expect(icon(:foo, 'Bar')).to be_a(ActiveSupport::SafeBuffer)
       end
     end
 


### PR DESCRIPTION
Usecase for this is primarily to be able to add addional classes, such as [the ones font-awesome provides](http://fontawesome.io/examples/).