### PR TITLE
Allows for a "way out" when building result object URLs in their respective classes.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    udongo (7.3.3)
+    udongo (7.3.4)
       acts_as_list (~> 0.7, >= 0.7.2)
       bcrypt (~> 3.1, >= 3.1.7)
       carrierwave (~> 0.10, >= 0.10.0)

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+7.3.4 - 2018-03-15
+--
+* Allow for a "way out" when building result objects for the frontend search.
+
+
 7.3.3 - 2018-03-09
 --
 * Make the youtube embed URLs a bit more flexible.

--- a/lib/udongo/search/base.rb
+++ b/lib/udongo/search/base.rb
@@ -44,10 +44,11 @@ module Udongo::Search
       # correct order.
       @indices ||= SearchModule.weighted.inject([]) do |stack, m|
         # The group happens to make sure we end up with just 1 copy of
-        # a searchable result Otherwise matches from both an indexed
+        # a searchable result. Otherwise matches from both an indexed
         # Page#title and Page#description would be in the result set.
-        stack << m.indices.where('search_indices.value REGEXP ?', term.value)
-          .group([:searchable_type, :searchable_id])
+        stack << m.indices
+                  .where('search_indices.value REGEXP ?', term.value)
+                  .group([:searchable_type, :searchable_id])
       end.flatten
     end
 

--- a/lib/udongo/search/frontend.rb
+++ b/lib/udongo/search/frontend.rb
@@ -12,10 +12,13 @@ module Udongo::Search
     #
     # Note that the result_object#url method is defined in
     # Udongo::Search::ResultObjects::Frontend::Page.
+    #
+    # If you return nil in the #url method of a result object, the item
+    # will get filtered out of the search results.
     def search
       indices.map do |index|
         result = result_object(index)
-        next if result.hidden? || result.unpublished?
+        next if result.hidden? || result.unpublished? || result.url.nil?
         { label: result.label, value: result.url }
       end.select(&:present?)
     end

--- a/lib/udongo/version.rb
+++ b/lib/udongo/version.rb
@@ -1,3 +1,3 @@
 module Udongo
-  VERSION = '7.3.3'
+  VERSION = '7.3.4'
 end

--- a/spec/lib/udongo/search/frontend_spec.rb
+++ b/spec/lib/udongo/search/frontend_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Udongo::Search::Frontend do
   let(:klass) { described_class.to_s.underscore.to_sym }
-  let(:instance) { described_class.new('foo') }
+  subject { described_class.new('foo') }
 
   before(:each) do
     module Udongo::Search::ResultObjects::Frontend
@@ -13,7 +13,7 @@ describe Udongo::Search::Frontend do
 
   describe '#search' do
     it 'default' do
-      expect(instance.search).to eq []
+      expect(subject.search).to eq []
     end
 
     context 'filters on visibility' do
@@ -27,9 +27,9 @@ describe Udongo::Search::Frontend do
         )
 
         index = create(:search_index, searchable: foo, locale: 'nl', name: 'description', value: 'foobar')
-        allow(instance).to receive(:indices) { [index] }
+        allow(subject).to receive(:indices) { [index] }
 
-        expect(instance.search).to eq [{ label: 'foobar', value: nil }]
+        expect(subject.search).to eq [{ label: 'foobar', value: nil }]
       end
 
       it 'skips hidden' do
@@ -42,9 +42,9 @@ describe Udongo::Search::Frontend do
         )
 
         index = create(:search_index, searchable: foo, locale: 'nl', name: 'description', value: 'foobar')
-        allow(instance).to receive(:indices) { [index] }
+        allow(subject).to receive(:indices) { [index] }
 
-        expect(instance.search).to eq []
+        expect(subject.search).to eq []
       end
     end
 
@@ -59,9 +59,9 @@ describe Udongo::Search::Frontend do
         )
 
         index = create(:search_index, searchable: foo, locale: 'nl', name: 'description', value: 'foobar')
-        allow(instance).to receive(:indices) { [index] }
+        allow(subject).to receive(:indices) { [index] }
 
-        expect(instance.search).to eq [{ label: 'foobar', value: nil }]
+        expect(subject.search).to eq [{ label: 'foobar', value: nil }]
       end
 
       it 'skips unpublished' do
@@ -74,15 +74,21 @@ describe Udongo::Search::Frontend do
         )
 
         index = create(:search_index, searchable: foo, locale: 'nl', name: 'description', value: 'foobar')
-        allow(instance).to receive(:indices) { [index] }
+        allow(subject).to receive(:indices) { [index] }
 
-        expect(instance.search).to eq []
+        expect(subject.search).to eq []
+      end
+
+      it 'skips indices that have no valid URL' do
+        # TODO: Currently only tested by live example, so review this later.
+        # I don't seem to end up within the scope of the #search method as I
+        # would assume.
       end
     end
   end
 
   it '#responds_to?' do
-    expect(instance).to respond_to(
+    expect(subject).to respond_to(
       :search, :indices, :result_object
     )
   end

--- a/spec/lib/udongo/search/frontend_spec.rb
+++ b/spec/lib/udongo/search/frontend_spec.rb
@@ -12,37 +12,30 @@ describe Udongo::Search::Frontend do
   end
 
   describe '#search' do
+    let(:foo) { Udongo::BogusModel.new(description: 'foobar') }
+    let(:index) { create(:search_index, searchable: foo, locale: 'nl', name: 'description', value: 'foobar') }
+
+    before do
+      allow(subject).to receive(:indices) { [index] }
+    end
+
     it 'default' do
       expect(subject.search).to eq []
     end
 
     context 'filters on visibility' do
       it 'shows visible' do
-        foo = Udongo::BogusModel.new(
-          description: 'foobar',
-          visible?: true,
-          hidden?: false,
-          published?: true,
-          unpublished?: false
-        )
+        allow(subject).to receive(:result_object).with(index) do
+          double(:result_object, hidden?: false, unpublished?: false, url: 'bar', label: 'foobar')
+        end
 
-        index = create(:search_index, searchable: foo, locale: 'nl', name: 'description', value: 'foobar')
-        allow(subject).to receive(:indices) { [index] }
-
-        expect(subject.search).to eq [{ label: 'foobar', value: nil }]
+        expect(subject.search).to eq [{ label: 'foobar', value: 'bar' }]
       end
 
       it 'skips hidden' do
-        foo = Udongo::BogusModel.new(
-          description: 'foobar',
-          visible?: false,
-          hidden?: true,
-          published?: true,
-          unpublished?: false
-        )
-
-        index = create(:search_index, searchable: foo, locale: 'nl', name: 'description', value: 'foobar')
-        allow(subject).to receive(:indices) { [index] }
+        allow(subject).to receive(:result_object).with(index) do
+          double(:result_object, hidden?: true, unpublished?: false, url: 'bar', label: 'foobar')
+        end
 
         expect(subject.search).to eq []
       end
@@ -50,39 +43,37 @@ describe Udongo::Search::Frontend do
 
     context 'filters on publishable state' do
       it 'shows published' do
-        foo = Udongo::BogusModel.new(
-          description: 'foobar',
-          visible?: true,
-          hidden?: false,
-          published?: true,
-          unpublished?: false
-        )
+        allow(subject).to receive(:result_object).with(index) do
+          double(:result_object, hidden?: false, unpublished?: false, url: 'bar', label: 'foobar')
+        end
 
-        index = create(:search_index, searchable: foo, locale: 'nl', name: 'description', value: 'foobar')
-        allow(subject).to receive(:indices) { [index] }
-
-        expect(subject.search).to eq [{ label: 'foobar', value: nil }]
+        expect(subject.search).to eq [{ label: 'foobar', value: 'bar' }]
       end
 
       it 'skips unpublished' do
-        foo = Udongo::BogusModel.new(
-          description: 'foobar',
-          visible?: true,
-          hidden?: false,
-          published?: false,
-          unpublished?: true
-        )
-
-        index = create(:search_index, searchable: foo, locale: 'nl', name: 'description', value: 'foobar')
-        allow(subject).to receive(:indices) { [index] }
+        allow(subject).to receive(:result_object).with(index) do
+          double(:result_object, hidden?: false, unpublished?: true, url: 'bar', label: 'foobar')
+        end
 
         expect(subject.search).to eq []
       end
+    end
 
-      it 'skips indices that have no valid URL' do
-        # TODO: Currently only tested by live example, so review this later.
-        # I don't seem to end up within the scope of the #search method as I
-        # would assume.
+    context 'filters on presence URL method result' do
+      it 'shows published' do
+        allow(subject).to receive(:result_object).with(index) do
+          double(:result_object, hidden?: false, unpublished?: false, url: 'bar', label: 'foobar')
+        end
+
+        expect(subject.search).to eq [{ label: 'foobar', value: 'bar' }]
+      end
+
+      it 'skips unpublished' do
+        allow(subject).to receive(:result_object).with(index) do
+          double(:result_object, hidden?: false, unpublished?: true, url: 'bar', label: 'foobar')
+        end
+
+        expect(subject.search).to eq []
       end
     end
   end


### PR DESCRIPTION
https://app.activecollab.com/167099/projects/1?modal=Task-320-1