### PR TITLE
Lets Udongo search ignore diacritics from search terms.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+7.5.1 - 2018-07-19
+--
+* Let Udongo search ignore diacritics in search terms.
+
+
 7.5.0 - 2018-06-13
 --
 * Make it possible to mark a content picture to be used in the background with a

--- a/lib/udongo/search/base.rb
+++ b/lib/udongo/search/base.rb
@@ -47,7 +47,7 @@ module Udongo::Search
         # a searchable result. Otherwise matches from both an indexed
         # Page#title and Page#description would be in the result set.
         stack << m.indices
-                  .where('search_indices.value REGEXP ?', term.value)
+                  .where('search_indices.value LIKE ?', "%#{term.value}%")
                   .group([:searchable_type, :searchable_id])
       end.flatten
     end


### PR DESCRIPTION
Port search query from REGEXP (which is faster) to LIKE (which can ignore diacritics). Note that this requires a UTF8 collation on your database tables (either utf8_unicode_ci or utf8_general_ci).