### PR TITLE
Camelcases the header keys in Udongo::Redirects::Response#headers to deal with badly formatted HTTP headers.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+7.8.1 - 2018-12-04
+--
+* Adds a hotfix to deal with badly formatted HTTP headers in 
+  Udongo::Redirects::Response#headers.
+
+
 7.8.0 - 2018-10-26
 --
 * Fixes issue with blank search terms giving an unwanted AR exception.

--- a/lib/udongo/redirects/response.rb
+++ b/lib/udongo/redirects/response.rb
@@ -13,7 +13,9 @@ module Udongo::Redirects
     # For now, the last location header is returned as a value.
     def headers
       list = @response.header_str.split(/[\r\n]+/).map(&:strip)
-      Hash[list.flat_map{ |s| s.scan(/^(\S+): (.+)/) }]
+      Hash[list.flat_map{ |s| s.scan(/^(\S+): (.+)/) }.map { |pair|
+        [pair.first.to_s.camelcase, pair.second]
+      }]
     end
 
     def raw

--- a/lib/udongo/version.rb
+++ b/lib/udongo/version.rb
@@ -1,3 +1,3 @@
 module Udongo
-  VERSION = '7.8.0'
+  VERSION = '7.8.1'
 end

--- a/spec/lib/udongo/redirects/response_spec.rb
+++ b/spec/lib/udongo/redirects/response_spec.rb
@@ -55,5 +55,11 @@ describe Udongo::Redirects::Response do
       subject = described_class.new(double(:response, header_str: header_string))
       expect(subject.headers['Location']).to eq 'http://reli.test/fr/provence/var/la-detente'
     end
+
+    it 'can handle lowercased location settings' do
+      header_string = "HTTP/1.1 301 Moved Permanently\r\nX-XSS-Protection: 1; mode=block\r\nX-Content-Type-Options: nosniff\r\nlocation: http://reli.test/fr/provence/var/detente\r\nContent-Type: text/html; charset=utf-8\r\nCache-Control: no-cache\r\nX-Request-Id: 716daafb-d9d3-4f5d-a9d4-141663b8f48a\r\nX-Runtime: 0.050885\r\nSet-Cookie: __profilin=p%3Dt; path=/\r\nDate: Fri, 26 Oct 2018 07:57:24 GMT\r\nConnection: close\r\n\r\nHTTP/1.1 301 Moved Permanently\r\nX-XSS-Protection: 1; mode=block\r\nX-Content-Type-Options: nosniff\r\nLocation: http://reli.test/fr/provence/var/la-detente\r\n\r\n"
+      subject = described_class.new(double(:response, header_str: header_string))
+      expect(subject.headers['Location']).to eq 'http://reli.test/fr/provence/var/la-detente'
+    end
   end
 end


### PR DESCRIPTION
https://app.activecollab.com/167099/my-work?modal=Task-1475-2